### PR TITLE
[UPDATE] 최신 Node.js 버전에서만 빌드 테스트하도록 변경

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: GitHub Action for Yarn
       uses: Borales/actions-yarn@v2.1.0
-    - run: sudo yarn
     - run: yarn build
     - run: yarn test
       env:


### PR DESCRIPTION
LTS인 12와 latest인 13에서만 테스트합니다. 개발은 13에서 진행되며, 실행은 12에서 되야합니다.