### PR TITLE
[ETC] Node 14 출시로 인한 테스트 버전 변경

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
노드 14가 출시되었습니다. 이에 맞춰 최신 노드 대응용 테스트 버전을 14로 변경합니다.