### PR TITLE
[FIX] API 문서 누락된 참조 추가

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -231,6 +231,8 @@ paths:
       summary: 학생이 선택한 자리에 노트북 대여를 요청합니다.
       parameters:
       - $ref: '#/components/parameters/Authorization'
+      requestBody:
+        $ref: '#/components/requestBodies/LaptopApply'
       responses:
         '201':
           description: 노트북 대여에 성공 하였을 경우
@@ -863,7 +865,11 @@ components:
                     type: array
                     items:
                       type: integer
-                    example: [1, 3, 5, 6]
+          example: {
+            data: {
+              seats: [1, 3, 5, 6]
+            }
+          }
     LaptopRoomReservationDetail:
       description: '해당 학습실의 자리를 예약한 사람의 정보들을 반환하는 응답입니다.'
       content:


### PR DESCRIPTION
###  API 문서 중 다음의 내용을 추가, 수정하였습니다.
- 노트북 API 중 노트북 신청 부분에서 누락되어있던 request body 참조 추가
- 노트북 API 중 학습실 대여 자리 조회 부분에서 예시를 올바르게 출력되도록 수정